### PR TITLE
Add a feature for slot migration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -343,14 +343,20 @@ type OutputStats struct {
 }
 
 type FilterConfig struct {
-	DbBlacklist  SliceInt         `yaml:"dbBlacklist"`
-	CmdBlacklist SliceString      `yaml:"commandBlacklist"`
-	KeyFilter    *FilterKeyConfig `yaml:"keyFilter"`
+	DbBlacklist  SliceInt          `yaml:"dbBlacklist"`
+	CmdBlacklist SliceString       `yaml:"commandBlacklist"`
+	KeyFilter    *FilterKeyConfig  `yaml:"keyFilter"`
+	SlotFilter   *FilterSlotConfig `yaml:"slotFilter"`
 }
 
 type FilterKeyConfig struct {
 	PrefixKeyWhitelist SliceString `yaml:"prefixKeyWhitelist"`
 	PrefixKeyBlacklist SliceString `yaml:"prefixKeyBlacklist"`
+}
+
+type FilterSlotConfig struct {
+	KeySlotWhitelist DoubleSliceUint16 `yaml:"keySlotWhitelist"`
+	KeySlotBlacklist DoubleSliceUint16 `yaml:"keySlotBlacklist"`
 }
 
 type LogHandlerFileConfig struct {

--- a/config/flags.go
+++ b/config/flags.go
@@ -124,10 +124,11 @@ func FlagsParseToStruct(prefix string, obj interface{}) {
 		case reflect.Slice:
 			kk := field.Type.Elem().Kind()
 			switch kk {
-			case reflect.String, reflect.Int:
+			case reflect.String, reflect.Int, reflect.Slice:
 				yy := (interface{})(val.Addr().Interface())
 				flag.Var((yy).(flag.Value), tag, usage)
 			}
+
 		default:
 			flagsParseType(field.Type.Kind(), val, tag, defVal, usage)
 		}

--- a/config/var.go
+++ b/config/var.go
@@ -301,29 +301,59 @@ func (ss *SliceString) Set(val string) error {
 
 type SliceInt []int
 
-func (ss *SliceInt) UnmarshalYAML(value *yaml.Node) error {
+func (si *SliceInt) UnmarshalYAML(value *yaml.Node) error {
 	var vv []int
 	if err := value.Decode(&vv); err != nil {
 		return err
 	}
-	*ss = vv
+	*si = vv
 	return nil
 }
 
 // for flag
-func (ss *SliceInt) String() string {
+func (si *SliceInt) String() string {
 	return "sliceint" // tag
 }
 
 // for flag
-func (ss *SliceInt) Set(val string) error {
+func (si *SliceInt) Set(val string) error {
 	vv := strings.Split(val, ",")
 	for _, v := range vv {
 		ii, err := strconv.Atoi(v)
 		if err != nil {
 			return err
 		}
-		*ss = append(*ss, ii)
+		*si = append(*si, ii)
+	}
+	return nil
+}
+
+type DoubleSliceUint16 [][]uint16
+
+// for flag
+func (d *DoubleSliceUint16) String() string {
+	return "doublesliceuint16"
+}
+
+//for flag ex: [0,1000],[1005,1006],[1995]
+func (d *DoubleSliceUint16) Set(value string) error {
+	value = strings.Trim(value, "[]")
+	slicesStr := strings.Split(value, "],[")
+
+	*d = make(DoubleSliceUint16, len(slicesStr))
+	for i, sliceStr := range slicesStr {
+		sliceStr = strings.TrimSpace(sliceStr)
+		numbersStr := strings.Split(sliceStr, ",")
+		numbers := make([]uint16, len(numbersStr))
+		for j, numberStr := range numbersStr {
+			numberStr = strings.TrimSpace(numberStr)
+			number, err := strconv.ParseUint(numberStr, 10, 16)
+			if err != nil {
+				return newConfigError("invalid number %s in slice at index %d: %w", numberStr, i, err)
+			}
+			numbers[j] = uint16(number)
+		}
+		(*d)[i] = numbers
 	}
 	return nil
 }

--- a/docs/configuration_en.md
+++ b/docs/configuration_en.md
@@ -113,7 +113,9 @@ Configuration:
 - keyFilter: Filtering keys
   - prefixKeyBlacklist: Prefix key blacklist
   - prefixKeyWhitelist: Prefix key whitelist
-
+- slotFilter: Filtering slots keys
+  - keySlotBlacklist : slots blacklist
+  - keySlotWhitelist : slots whitelist
 
 Configuration example, not synchronizing `del` commands and keys starting with `redisGunYu`:
 ```
@@ -123,6 +125,10 @@ filter:
   keyFilter:
     prefixKeyBlacklist: 
       - redisGunYu
+  slotFilter:
+    keySlotWhitelist: 
+      - [0,1000]
+      - [1002] 
 ```
 
 
@@ -252,6 +258,16 @@ input:
 ```
 
 The corresponding command line argument would be `--sync.input.redis.addresses=127.0.0.1:6379,127.0.0.2:6379`.
+
+For example, if the slots white list are configured as follows in the configuration file:
+```
+filter:
+  slotFilter:
+    keySlotWhitelist: 
+      - [0,1000]
+      - [1002] 
+```
+The corresponding command line argument would be`--sync.filter.slotFilter.keySlotWhitelist=[0,1000],[1002]`
 
 You can use `redisGunYu -h` to view all available arguments.
 

--- a/docs/configuration_zh.md
+++ b/docs/configuration_zh.md
@@ -114,6 +114,10 @@ output配置如下：
 - keyFilter: 对key进行过滤
   - prefixKeyBlacklist : 前缀key黑名单
   - prefixKeyWhitelist : 前缀key白名单
+- slotFilter: 对slot进行过滤
+  - keySlotBlacklist : slot黑名单
+  - keySlotWhitelist : slot白名单
+  
 
 
 如下配置，不同步del命令，也不同步redisGunYu开头的key
@@ -124,6 +128,10 @@ filter:
   keyFilter:
     prefixKeyBlacklist: 
       - redisGunYu
+  slotFilter:
+    keySlotWhitelist: 
+      - [0,1000]
+      - [1002] 
 ```
 
 
@@ -260,6 +268,16 @@ input:
 ```
 
 则命令行名为`--sync.input.redis.addresses=127.0.0.1:6379,127.0.0.2:6379`
+
+如槽位白名单，配置文件如下，
+```
+filter:
+  slotFilter:
+    keySlotWhitelist: 
+      - [0,1000]
+      - [1002] 
+```
+则命令行名为`--sync.filter.slotFilter.keySlotWhitelist=[0,1000],[1002]`
 
 可以通过`redisGunYu -h`来查看都有哪些参数。
 

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -112,15 +112,6 @@ func (f *RedisCmdFilter) FilterKey(key string) bool {
 	return false
 }
 
-func (f *RedisCmdFilter) FilterKeyBySlot(key string, startSlot, endSlot uint16) bool {
-	keySlot := redis.KeyToSlot(key)
-
-	if keySlot >= startSlot && keySlot <= endSlot {
-		return true
-	}
-	return false
-}
-
 // filter out
 func FilterDB(db int) bool {
 	if db == -1 {

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -2,7 +2,6 @@ package filter
 
 import (
 	"github.com/mgtv-tech/redis-GunYu/pkg/log"
-	"github.com/mgtv-tech/redis-GunYu/pkg/redis"
 	"strings"
 
 	"github.com/mgtv-tech/redis-GunYu/config"

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -17,6 +17,11 @@ func TestFilter(t *testing.T) {
 			assert.Equal(t, exps[i], flt.FilterKey(c))
 		}
 	}
+	filterSlotChecker := func(t *testing.T, flt *RedisCmdFilter, keys []string, exps []bool) {
+		for i, c := range keys {
+			assert.Equal(t, exps[i], flt.FilterSlot(c))
+		}
+	}
 
 	type cmdKey struct {
 		cmd     string

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -17,11 +17,6 @@ func TestFilter(t *testing.T) {
 			assert.Equal(t, exps[i], flt.FilterKey(c))
 		}
 	}
-	filterSlotChecker := func(t *testing.T, flt *RedisCmdFilter, keys []string, exps []bool) {
-		for i, c := range keys {
-			assert.Equal(t, exps[i], flt.FilterSlot(c))
-		}
-	}
 
 	type cmdKey struct {
 		cmd     string

--- a/pkg/filter/range.go
+++ b/pkg/filter/range.go
@@ -1,0 +1,33 @@
+package filter
+
+import "github.com/mgtv-tech/redis-GunYu/pkg/redis"
+
+type Range struct {
+	Left, Right uint16
+}
+
+type RangeList struct {
+	list []*Range
+}
+
+func NewRangeList() *RangeList {
+	return &RangeList{
+		list: make([]*Range, 0),
+	}
+}
+
+func (rl *RangeList) IsSlotInList(key string) bool {
+	keySlot := redis.KeyToSlot(key)
+	for _, r := range rl.list {
+		if keySlot >= r.Left && keySlot <= r.Right {
+			return true
+		}
+	}
+	return false
+}
+
+func (rl *RangeList) InsertSlotInList(left, right uint16) {
+	if left <= right {
+		rl.list = append(rl.list, &Range{Left: left, Right: right})
+	}
+}

--- a/pkg/filter/range.go
+++ b/pkg/filter/range.go
@@ -23,8 +23,6 @@ func NewRangeList() *RangeList {
 	}
 }
 
-type ByLeft []*Range
-
 func (rl *RangeList) IsSlotInList(key string) bool {
 	keySlot := redis.KeyToSlot(key)
 	if len(rl.list) == 0 {

--- a/pkg/filter/range.go
+++ b/pkg/filter/range.go
@@ -20,11 +20,11 @@ func NewRangeList() *RangeList {
 }
 
 func (rl *RangeList) IsSlotInList(key string) bool {
-	keySlot := redis.KeyToSlot(key)
 	if len(rl.list) == 0 {
 		return false
 	}
-
+	keySlot := redis.KeyToSlot(key)
+	
 	left, right := 0, len(rl.list)-1
 	for left <= right {
 		mid := left + (right-left)/2

--- a/pkg/filter/range.go
+++ b/pkg/filter/range.go
@@ -19,12 +19,6 @@ func NewRangeList() *RangeList {
 	}
 }
 
-type ByLeft []*Range  
-  
-func (a ByLeft) Len() int           { return len(a) }  
-func (a ByLeft) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }  
-func (a ByLeft) Less(i, j int) bool { return a[i].Left < a[j].Left } 
-
 func (rl *RangeList) IsSlotInList(key string) bool {
 	keySlot := redis.KeyToSlot(key)
 	if len(rl.list) == 0 {

--- a/pkg/filter/range.go
+++ b/pkg/filter/range.go
@@ -11,20 +11,29 @@ type Range struct {
 
 type RangeList struct {
 	list []*Range
+	minLeft  uint16
+	maxRight uint16
 }
 
 func NewRangeList() *RangeList {
 	return &RangeList{
 		list: make([]*Range, 0),
+		minLeft:  0,
+		maxRight: 0,
 	}
 }
 
+type ByLeft []*Range
+
 func (rl *RangeList) IsSlotInList(key string) bool {
+	keySlot := redis.KeyToSlot(key)
 	if len(rl.list) == 0 {
 		return false
 	}
-	keySlot := redis.KeyToSlot(key)
-	
+	if keySlot < rl.minLeft || keySlot > rl.maxRight {
+		return false
+	}
+
 	left, right := 0, len(rl.list)-1
 	for left <= right {
 		mid := left + (right-left)/2
@@ -49,5 +58,11 @@ func (rl *RangeList) InsertSlotInList(left, right uint16) {
 		rl.list = append(rl.list, nil)
 		copy(rl.list[i+1:], rl.list[i:])
 		rl.list[i] = newRange
+		if left < rl.minLeft {
+			rl.minLeft = left
+		}
+		if right > rl.maxRight {
+			rl.maxRight = right
+		}
 	}
 }

--- a/pkg/filter/range.go
+++ b/pkg/filter/range.go
@@ -19,6 +19,12 @@ func NewRangeList() *RangeList {
 	}
 }
 
+type ByLeft []*Range  
+  
+func (a ByLeft) Len() int           { return len(a) }  
+func (a ByLeft) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }  
+func (a ByLeft) Less(i, j int) bool { return a[i].Left < a[j].Left } 
+
 func (rl *RangeList) IsSlotInList(key string) bool {
 	keySlot := redis.KeyToSlot(key)
 	if len(rl.list) == 0 {

--- a/syncer/input.go
+++ b/syncer/input.go
@@ -593,6 +593,7 @@ func (ri *RedisInput) sendPsync(cli *redis.StandaloneRedis, offset Offset) (Offs
 		ri.logger.Errorf("send psync : offset(%v), err(%v), input(%s, %d)", offset, err, pRunId, pOff)
 		return Offset{}, false, 0, err
 	}
+
 	var rdbSize int64
 	if wait == nil {
 		ri.logger.Debugf("send psync : offset(%v), input(%s, %d), aof_sync", offset, pRunId, pOff)

--- a/syncer/output.go
+++ b/syncer/output.go
@@ -158,6 +158,12 @@ func NewRedisOutput(cfg RedisOutputConfig) *RedisOutput {
 		ro.outFilter.InsertPrefixKeyWhiteList(keyFilter.PrefixKeyWhitelist)
 	}
 
+	slotFilter := config.Get().Filter.SlotFilter
+	if slotFilter != nil {
+		ro.outFilter.InsertSlotWhiteList(slotFilter.KeySlotWhitelist)
+		ro.outFilter.InsertSlotBlackList(slotFilter.KeySlotBlacklist)
+	}
+
 	return ro
 }
 
@@ -344,7 +350,8 @@ func (ro *RedisOutput) rdbReplay(ctx context.Context, pipe <-chan *rdb.BinEntry)
 				}
 			}
 
-			if ro.outFilter.FilterKey(util.BytesToString(e.Key)) {
+			if ro.outFilter.FilterKey(util.BytesToString(e.Key)) ||
+				ro.outFilter.FilterSlot(util.BytesToString(e.Key)){
 				filterOut = true
 			}
 		}


### PR DESCRIPTION
In this configuration scheme, the slotFilter employs both a blacklist and a whitelist to filter slot keys. The blacklist takes precedence, effectively filtering out any slots that are listed within it, even if they are also included in the whitelist. This approach ensures that slots listed in the blacklist are not processed or synchronized, regardless of their presence in the whitelist.

keySlotBlacklist: Defines a list of slot numbers or ranges that are filtered out from any processing or synchronization activities. Slots falling within this list will be excluded, overriding any permissive entries in the whitelist.
keySlotWhitelist: Specifies a list of slot numbers or ranges that are typically allowed for processing or synchronization. However, due to the blacklist's overriding nature, slots listed in both the blacklist and whitelist will still be filtered out.
Example Configuration (Assuming Blacklist Overrides Whitelist):

filter:  
  slotFilter:  
    keySlotBlacklist:   
      - [1001, 1010]  # Filters out slots from 1001 to 1010, overriding any whitelist entries  
    keySlotWhitelist:   
      - [0, 2000]     # Allows slots from 0 to 2000 in principle, but those in the blacklist range are filtered out
    
In this revised example, the term "reject" has been replaced with "filter out" to reflect the more neutral and technical nature of the process. Slots within the blacklist range are "filtered out" from processing or synchronization, even if they would otherwise be allowed by the whitelist.