### PR TITLE
Add a feature：adapt proxy type Redis for loading rdb

### DIFF
--- a/cmd/rdb.go
+++ b/cmd/rdb.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/mgtv-tech/redis-GunYu/pkg/log"
 	"io"
 	"os"
 	"sync/atomic"
@@ -108,7 +109,14 @@ func (rc *RdbCmd) Load(rdbPath string, cfg *config.RdbCmdLoad) error {
 
 	err = redis.FixVersion(cfg.Redis)
 	if err != nil {
-		return err
+		log.Warnf("failed to get version from target redis, instead get version from rdb!")
+		redisVersion, err := rdbRd.GetVersion()
+		if err != nil {
+			log.Errorf("redis get version from rdb error : error(%v)", err)
+			return err
+		}
+		log.Infof("redis rdb version : %s", redisVersion)
+		cfg.Redis.Version = redisVersion
 	}
 	if err = redis.FixTopology(cfg.Redis); err != nil {
 		return err

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ var (
 
 func init() {
 	syncCfg = &SyncConfig{}
+	rdbCfg = &RdbCmdConfig{}
 }
 
 func GetSyncerConfig() *SyncConfig {
@@ -459,6 +460,20 @@ func InitSyncerConfig(path string) error {
 		return err
 	}
 	if err = syncCfg.fix(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func InitRdbConfig(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	if err = yaml.Unmarshal(data, rdbCfg); err != nil {
+		return err
+	}
+	if err = rdbCfg.fix(); err != nil {
 		return err
 	}
 	return nil

--- a/config/flags.go
+++ b/config/flags.go
@@ -31,7 +31,7 @@ type Flags struct {
 
 type RdbCmdConfig struct {
 	Action  string
-	RdbPath string
+	RdbPath string       `yaml:"rdbPath"`
 	Print   RdbCmdPrint
 	Load    RdbCmdLoad
 }
@@ -115,7 +115,7 @@ func LoadFlags() error {
 			return err
 		}
 		logCfg = syncCfg.Log
-	} else if flagVar.Cmd == "rdb" {
+	} else if flagVar.Cmd == "rdb"  && len(flagVar.ConfigPath) == 0 {
 		rdbCfg = &tmpRdbCfg
 		FlagsSetToStruct(rdbCfg)
 		if err := rdbCfg.fix(); err != nil {

--- a/docs/rdb_en.md
+++ b/docs/rdb_en.md
@@ -35,7 +35,7 @@ action: load
 rdbPath: /tmp/test.rdb
 load:
   redis:
-    addresses: 127.0.0.1:6379,127.0.0.1:6479
+    addresses: [127.0.0.1:6379,127.0.0.1:6479]
     type: cluster
   filter:
     dbBlacklist: 1

--- a/docs/rdb_zh.md
+++ b/docs/rdb_zh.md
@@ -37,7 +37,7 @@ action: load
 rdbPath: /tmp/test.rdb
 load:
   redis:
-    addresses: 127.0.0.1:6379,127.0.0.1:6479
+    addresses: [127.0.0.1:6379,127.0.0.1:6479]
     type: cluster
   filter:
     dbBlacklist: 1

--- a/main.go
+++ b/main.go
@@ -35,6 +35,9 @@ func runCmd() error {
 		cmder = cmd.NewSyncerCmd()
 		gracefullTimeout = config.GetSyncerConfig().Server.GracefullStopTimeout
 	case "rdb":
+		if config.GetFlag().ConfigPath != "" {
+			panicIfError(config.InitRdbConfig(config.GetFlag().ConfigPath))
+		}
 		cmder = cmd.NewRdbCmd()
 	case "aof":
 		cmder = cmd.NewAofCmd()


### PR DESCRIPTION
1. If the destination is a proxy type cluster Redis, get the version from the rdb file.
2. Fix the issue where load rdb cannot use configuration files