### PR TITLE
a new feature：adapt proxy type Redis for loading rdb

### DIFF
--- a/cmd/rdb.go
+++ b/cmd/rdb.go
@@ -109,9 +109,6 @@ func (rc *RdbCmd) Load(rdbPath string, cfg *config.RdbCmdLoad) error {
 
 	err = redis.FixVersion(cfg.Redis)
 	if err != nil {
-		return err
-	}
-	if err != nil {
 		log.Warnf("failed to get version from target redis, instead get version from rdb!")
 		redisVersion, err := rdb.ParseRdbVersion(rdbRd.GetReader())
 		if err != nil {

--- a/cmd/rdb.go
+++ b/cmd/rdb.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/mgtv-tech/redis-GunYu/pkg/log"
 	"io"
 	"os"
 	"sync/atomic"
@@ -109,6 +110,16 @@ func (rc *RdbCmd) Load(rdbPath string, cfg *config.RdbCmdLoad) error {
 	err = redis.FixVersion(cfg.Redis)
 	if err != nil {
 		return err
+	}
+	if err != nil {
+		log.Warnf("failed to get version from target redis, instead get version from rdb!")
+		redisVersion, err := rdb.ParseRdbVersion(rdbRd.GetReader())
+		if err != nil {
+			log.Errorf("redis get version from rdb error : error(%v)", err)
+			return err
+		}
+		log.Infof("redis rdb version : %s", redisVersion)
+		cfg.Redis.Version = redisVersion
 	}
 	if err = redis.FixTopology(cfg.Redis); err != nil {
 		return err

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ var (
 
 func init() {
 	syncCfg = &SyncConfig{}
+	rdbCfg = &RdbCmdConfig{}
 }
 
 func GetSyncerConfig() *SyncConfig {
@@ -459,6 +460,20 @@ func InitSyncerConfig(path string) error {
 		return err
 	}
 	if err = syncCfg.fix(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func InitRdbConfig(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	if err = yaml.Unmarshal(data, rdbCfg); err != nil {
+		return err
+	}
+	if err = rdbCfg.fix(); err != nil {
 		return err
 	}
 	return nil

--- a/config/flags.go
+++ b/config/flags.go
@@ -31,7 +31,7 @@ type Flags struct {
 
 type RdbCmdConfig struct {
 	Action  string
-	RdbPath string
+	RdbPath string       `yaml:"rdbPath"`
 	Print   RdbCmdPrint
 	Load    RdbCmdLoad
 }
@@ -115,7 +115,7 @@ func LoadFlags() error {
 			return err
 		}
 		logCfg = syncCfg.Log
-	} else if flagVar.Cmd == "rdb" {
+	} else if flagVar.Cmd == "rdb"  && len(flagVar.ConfigPath) == 0 {
 		rdbCfg = &tmpRdbCfg
 		FlagsSetToStruct(rdbCfg)
 		if err := rdbCfg.fix(); err != nil {

--- a/docs/rdb_en.md
+++ b/docs/rdb_en.md
@@ -35,7 +35,7 @@ action: load
 rdbPath: /tmp/test.rdb
 load:
   redis:
-    addresses: 127.0.0.1:6379,127.0.0.1:6479
+    addresses: [127.0.0.1:6379,127.0.0.1:6479]
     type: cluster
   filter:
     dbBlacklist: 1

--- a/docs/rdb_zh.md
+++ b/docs/rdb_zh.md
@@ -37,7 +37,7 @@ action: load
 rdbPath: /tmp/test.rdb
 load:
   redis:
-    addresses: 127.0.0.1:6379,127.0.0.1:6479
+    addresses: [127.0.0.1:6379,127.0.0.1:6479]
     type: cluster
   filter:
     dbBlacklist: 1

--- a/main.go
+++ b/main.go
@@ -35,6 +35,9 @@ func runCmd() error {
 		cmder = cmd.NewSyncerCmd()
 		gracefullTimeout = config.GetSyncerConfig().Server.GracefullStopTimeout
 	case "rdb":
+		if config.GetFlag().ConfigPath != "" {
+			panicIfError(config.InitRdbConfig(config.GetFlag().ConfigPath))
+		}
 		cmder = cmd.NewRdbCmd()
 	case "aof":
 		cmder = cmd.NewAofCmd()

--- a/pkg/rdb/rdb.go
+++ b/pkg/rdb/rdb.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"sync/atomic"
 
 	"github.com/mgtv-tech/redis-GunYu/pkg/common"
@@ -92,4 +93,94 @@ func (r *CountReader) Read(p []byte) (int, error) {
 	n, err := r.r.Read(p)
 	r.p.Add(int64(n))
 	return n, err
+}
+
+const (
+	RdbRedisSignature   = "REDIS"
+	RdbAuxFieldMarker   = 0xFA
+	RdbRedisVersionKey  = "redis-ver"
+)
+
+func ParseRdbVersion(reader *os.File) (string, error) {
+	if reader == nil {
+		return "", errors.New("RDB file is not opened")
+	}
+
+	// save initial read location
+	startPos, err := reader.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return "", err
+	}
+
+	// reset to the beginning of the file
+	_, err = reader.Seek(0, io.SeekStart)
+	if err != nil {
+		return "", err
+	}
+
+	signature := make([]byte, len(RdbRedisSignature))
+	_, err = io.ReadFull(reader, signature)
+	if err != nil {
+		return restorePosition(reader, startPos, "",  err)
+	}
+	if string(signature) != RdbRedisSignature {
+		return restorePosition(reader, startPos, "", errors.New("invalid RDB file signature"))
+	}
+
+	// Skip RDB version
+	_, err = reader.Seek(4, io.SeekCurrent)
+	if err != nil {
+		return restorePosition(reader, startPos, "", err)
+	}
+
+	// read AUX field
+	for {
+		buf := make([]byte, 1)
+		_, err := io.ReadFull(reader, buf)
+		if err != nil {
+			if err == io.EOF {
+				err = errors.New("unexpected end of file")
+			}
+			return restorePosition(reader, startPos, "", err)
+		}
+		if buf[0] == RdbAuxFieldMarker {
+			key, err := readAuxValue(reader)
+			if err != nil {
+				return restorePosition(reader, startPos, "", err)
+			}
+			if string(key) == RdbRedisVersionKey {
+				val, err := readAuxValue(reader)
+				if err != nil {
+					return restorePosition(reader, startPos, "", err)
+				}
+				return restorePosition(reader, startPos, string(val), nil) // Restore position on success
+			} else {
+				break
+			}
+		} else {
+			break
+		}
+	}
+
+	return restorePosition(reader, startPos, "", errors.New("version number not found in AUX fields"))
+}
+
+func readAuxValue(reader *os.File) ([]byte, error) {
+	valLenBuf := make([]byte, 1)
+	_, err := io.ReadFull(reader, valLenBuf)
+	if err != nil {
+		return nil, err
+	}
+	val := make([]byte, int(valLenBuf[0]))
+	_, err = io.ReadFull(reader, val)
+	return val, err
+}
+
+func restorePosition(reader *os.File, startPos int64, version string, err error) (string, error) {
+	if err == nil {
+		if _, seekErr := reader.Seek(startPos, io.SeekStart); seekErr != nil {
+			err = seekErr
+		}
+	}
+	return version, err
 }

--- a/pkg/store/rdb_reader.go
+++ b/pkg/store/rdb_reader.go
@@ -214,3 +214,7 @@ func (r *RdbReader) closeRdb() error {
 func (r *RdbReader) Size() int64 {
 	return r.size
 }
+
+func (r *RdbReader) GetReader() *os.File {
+	return r.reader
+}


### PR DESCRIPTION
1. If the destination is a proxy type cluster Redis, get the version from the rdb file.
2. Fix the issue where load rdb cannot use configuration files