### PR TITLE
 fix: not support hincrby command

### DIFF
--- a/pkg/rdb/loader_test.go
+++ b/pkg/rdb/loader_test.go
@@ -497,6 +497,18 @@ func (ts *hashTestSuite) TestHashRdb8() {
 	ts.hash(expData, longStrs, RdbTypeHash)
 }
 
+func (ts *hashTestSuite) TestHincrby() {
+	ts.redisVersion = "4.0"
+	// hincrby k2 f1 44467
+	ts.rdbDumpData = "524544495330303038fa0972656469732d76657205342e302e38fa0a72656469732d62697473c040fa056374696d65c201ab3667fa08757365642d6d656dc2083f6b14fa0e7265706c2d73747265616d2d6462c000fa077265706c2d69642862663430326136396562316334373461626231613732633335333335616266316434323561303564fa0b7265706c2d6f6666736574c2a7631c00fa0c616f662d707265616d626c65c000fe00fb01000d026b3214140000000e00000002000002663104f0b3ad00ffff0000000000000000"
+	entries := ts.decodeHexRdb(ts.rdbDumpData, 1)
+	entry := entries["k2"]
+	ts.Equal(RdbTypeHashZiplist, entry.ObjectParser.RdbType())
+	kvs := ts.entryToMap(entry)
+	ts.Equal(1, len(kvs))
+	ts.Equal(kvs["f1"], "44467")
+}
+
 func (ts *hashTestSuite) hash(hexData string, vals []interface{}, rdbType int) {
 	ts.Run("hash", func() {
 		key := "test_hash_key"

--- a/pkg/redis/client/cluster/conn.go
+++ b/pkg/redis/client/cluster/conn.go
@@ -96,7 +96,7 @@ func (conn *redisConn) flush() error {
 
 func (conn *redisConn) receive() (interface{}, error) {
 	if conn.readTimeout > 0 {
-		conn.c.SetWriteDeadline(time.Now().Add(conn.readTimeout))
+		conn.c.SetReadDeadline(time.Now().Add(conn.readTimeout))
 	}
 
 	if conn.pending.Load() <= 0 {

--- a/pkg/util/slice_buffer.go
+++ b/pkg/util/slice_buffer.go
@@ -117,5 +117,7 @@ func (s *SliceBuffer) ReadUint16() uint16 {
 
 func (s *SliceBuffer) ReadUint24() uint32 {
 	bb := s.Slice(3)
-	return binary.LittleEndian.Uint32(bb)
+	newBb := make([]byte, 4)
+	copy(newBb, bb)
+	return binary.LittleEndian.Uint32(newBb)
 }


### PR DESCRIPTION
当存储hash结构数据，hincrby k1 f1 44467时，由于redis采用rdbZiplistInt24编码，ReadUint24方法存在数组越界问题，导致同步失败