### PR TITLE
fixed issue #108

### DIFF
--- a/docs/release_v1.1.2_en.md
+++ b/docs/release_v1.1.2_en.md
@@ -1,0 +1,65 @@
+# redis-GunYu v1.1.2 Release Notes
+
+## 1. Overview
+
+`v1.1.2` is a patch release on top of `v1.1.1`, focused on fixing incorrect `SELECT` command encoding for multi-digit Redis DB indexes in standalone sync scenarios.
+
+This version does not introduce new feature switches or configuration format changes. Its primary goal is to fix incremental replay and resume failures when `db >= 10`, and it is intended as a direct upgrade from `v1.1.1`.
+
+## 2. Highlights
+
+### 2.1 Fixed AOF Replay for Multi-Digit DB Indexes
+
+- Fixed the DB index encoding used when rebuilding `SELECT` commands in the output-side AOF replay path
+- The previous implementation only worked for `db 0..9`; when the target DB was `10` or higher, the DB index could be encoded as a single incorrect byte
+- In standalone-to-standalone sync, this could cause the target Redis to return `ERR value is not an integer or out of range`
+
+### 2.2 Fixed Resume-From-Breakpoint for Multi-Digit DB Indexes
+
+- Fixed the same encoding issue when restoring the starting DB during `resumeFromBreakPoint`
+- When the checkpoint DB is `10` or higher, sync can now resume on the correct DB instead of failing on the first `SELECT`
+
+### 2.3 Added Regression Coverage
+
+- Added an AOF replay regression test for `SELECT 10`
+- Added a regression test for resume startup with a multi-digit DB index
+- Added a regression test for `targetDbMap` remapping to a multi-digit target DB
+
+## 3. Scope of Impact
+
+The affected cases are primarily:
+
+- standalone Redis as the output target
+- AOF incremental replay that reaches `SELECT 10` or higher
+- resume flow restoring to `db >= 10`
+- `targetDb` / `targetDbMap` remapping into `db >= 10`
+
+The following cases are typically unaffected:
+
+- standalone sync using only `db 0..9`
+- Redis Cluster as the output target
+- the RDB full-replay path
+
+## 4. Compatibility and Upgrade Notes
+
+- `v1.1.2` does not introduce configuration-breaking changes
+- Existing `v1.1.1` configurations can be reused directly
+- Regression coverage has been added for `db 10+` scenarios, so no parameter changes are required after upgrade
+
+If incremental sync was interrupted before the fix, validate the following after upgrade:
+
+- whether the syncer continues advancing offsets
+- whether writes to target `db 10+` resume correctly
+- whether `ERR value is not an integer or out of range` no longer appears in logs
+
+## 5. Recommended Upgrade Scenarios
+
+If you are currently using `v1.1.1`, upgrading to `v1.1.2` is recommended when any of the following applies:
+
+- your workload uses Redis logical DB `10` or higher
+- `resumeFromBreakPoint` is enabled
+- you use `targetDb` or `targetDbMap` for DB remapping
+
+## 6. Related Issue
+
+- Issue: `#108` `When the Redis sync DB index is greater than 10, data is no longer replicated`

--- a/docs/release_v1.1.2_zh.md
+++ b/docs/release_v1.1.2_zh.md
@@ -1,0 +1,65 @@
+# redis-GunYu v1.1.2 发布说明
+
+## 1. 版本概述
+
+`v1.1.2` 是基于 `v1.1.1` 的补丁版本，聚焦修复 standalone 同步场景下 `SELECT` 命令对双位数 Redis DB 编号的编码错误。
+
+本版本不引入新的功能开关，也不涉及配置格式变更。主要目标是修复 `db >= 10` 时的增量回放与断点续传失败问题，适合作为 `v1.1.1` 的直接升级版本。
+
+## 2. 主要更新
+
+### 2.1 修复双位数 DB 的 AOF 回放问题
+
+- 修复输出侧 AOF 解析后重组 `SELECT` 命令时的 DB 编号编码错误
+- 之前的实现仅适用于 `db 0..9`，当目标 DB 为 `10` 及以上时，可能将 DB 编号错误编码为单字节字符
+- 在 standalone 到 standalone 的同步场景下，这会导致目标 Redis 返回 `ERR value is not an integer or out of range`
+
+### 2.2 修复断点续传恢复到双位数 DB 的问题
+
+- 修复 `resumeFromBreakPoint` 场景下恢复起始 DB 时的同类编码问题
+- 当 checkpoint 记录的 DB 为 `10` 及以上时，重启后可正确恢复到对应 DB，而不会在首次 `SELECT` 时失败
+
+### 2.3 补充回归测试
+
+- 新增 `SELECT 10` 的 AOF 解析回归测试
+- 新增断点续传起始 DB 为双位数时的回归测试
+- 新增 `targetDbMap` 映射到双位数目标 DB 时的回归测试
+
+## 3. 影响范围
+
+受影响的主要是以下场景：
+
+- 输出端为 standalone Redis
+- AOF 增量回放过程中出现 `SELECT 10` 及以上 DB
+- 或者断点续传恢复到 `db >= 10`
+- 或者通过 `targetDb` / `targetDbMap` 将命令映射到 `db >= 10`
+
+以下场景通常不受影响：
+
+- 仅使用 `db 0..9` 的 standalone 同步
+- 输出端为 Redis Cluster 的场景
+- RDB 全量回放路径
+
+## 4. 兼容性与升级说明
+
+- `v1.1.2` 不引入配置破坏性变更
+- `v1.1.1` 的配置可直接沿用
+- 已经在 `db 10+` 受影响场景上补充回归测试，升级后无需调整已有参数
+
+如果故障期间已经发生增量中断，建议升级后重点验证：
+
+- syncer 是否能继续推进 offset
+- 目标端 `db 10+` 是否恢复写入
+- 日志中是否不再出现 `ERR value is not an integer or out of range`
+
+## 5. 建议升级对象
+
+如果你当前使用 `v1.1.1`，并且符合以下任一场景，建议优先升级到 `v1.1.2`：
+
+- 业务使用了 `db 10` 及以上的 Redis 逻辑库
+- 开启了 `resumeFromBreakPoint`
+- 使用 `targetDb` 或 `targetDbMap` 做 DB 映射
+
+## 6. 相关问题与提交
+
+- Issue: `#108` `当redis同步数据库下标设置超过10后，数据就不同步了，是存在问题还是功能限制呢？`

--- a/syncer/output.go
+++ b/syncer/output.go
@@ -685,12 +685,7 @@ func (ro *RedisOutput) parseAofCommand(replayQuit usync.WaitCloser, reader *bufi
 
 	if ro.startDbId > 0 { // select db
 		select {
-		case sendBuf <- cmdExecution{
-			Cmd:    "select",
-			Args:   []interface{}{[]byte{byte(ro.startDbId + '0')}},
-			Offset: startOffset,
-			Db:     ro.startDbId,
-		}:
+		case sendBuf <- buildSelectCmdExecution(ro.startDbId, startOffset):
 		case <-replayQuit.Context().Done():
 			return nil
 		}
@@ -763,12 +758,7 @@ func (ro *RedisOutput) parseAofCommand(replayQuit usync.WaitCloser, reader *bufi
 			if sdb, ok := ro.selectDB(currentDB, selectDB); ok {
 				currentDB = sdb
 				select {
-				case sendBuf <- cmdExecution{
-					Cmd:    "select",
-					Args:   []interface{}{[]byte{byte(currentDB + '0')}},
-					Offset: startOffset + incrOffset,
-					Db:     currentDB,
-				}:
+				case sendBuf <- buildSelectCmdExecution(currentDB, startOffset+incrOffset):
 				case <-replayQuit.Context().Done():
 					return nil
 				}
@@ -813,6 +803,15 @@ func (ro *RedisOutput) parseAofCommand(replayQuit usync.WaitCloser, reader *bufi
 	}
 
 	return nil
+}
+
+func buildSelectCmdExecution(db int, offset int64) cmdExecution {
+	return cmdExecution{
+		Cmd:    "select",
+		Args:   []interface{}{[]byte(strconv.Itoa(db))},
+		Offset: offset,
+		Db:     db,
+	}
 }
 
 func (ro *RedisOutput) StartPoint(ctx context.Context, runIds []string) (sp StartPoint, err error) {

--- a/syncer/output_test.go
+++ b/syncer/output_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -144,6 +145,92 @@ func TestSendAofRejectsInjectedTxnExecReplyError(t *testing.T) {
 	}
 }
 
+func TestParseAofCommandEncodesMultiDigitSelectDB(t *testing.T) {
+	ro := newReplyTestOutput()
+	replayQuit := usync.NewWaitCloser(nil)
+	sendBuf := make(chan cmdExecution, 4)
+
+	var payload bytes.Buffer
+	writeAofCommand(t, &payload, "SELECT", "10")
+	writeAofCommand(t, &payload, "SET", "k", "v")
+
+	err := ro.parseAofCommand(replayQuit, bufio.NewReader(bytes.NewReader(payload.Bytes())), 100, sendBuf)
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("expected EOF, got %v", err)
+	}
+
+	selectCmd := <-sendBuf
+	if selectCmd.Cmd != "select" {
+		t.Fatalf("expected select command, got %q", selectCmd.Cmd)
+	}
+	if got := string(selectCmd.Args[0].([]byte)); got != "10" {
+		t.Fatalf("unexpected select arg: got %q want %q", got, "10")
+	}
+	if selectCmd.Db != 10 {
+		t.Fatalf("unexpected select db: got %d want %d", selectCmd.Db, 10)
+	}
+
+	setCmd := <-sendBuf
+	if setCmd.Cmd != "set" {
+		t.Fatalf("expected set command, got %q", setCmd.Cmd)
+	}
+	if setCmd.Db != 10 {
+		t.Fatalf("unexpected set db: got %d want %d", setCmd.Db, 10)
+	}
+}
+
+func TestParseAofCommandEncodesResumeStartDB(t *testing.T) {
+	ro := newReplyTestOutput()
+	ro.startDbId = 12
+	replayQuit := usync.NewWaitCloser(nil)
+	sendBuf := make(chan cmdExecution, 2)
+
+	err := ro.parseAofCommand(replayQuit, bufio.NewReader(bytes.NewReader(nil)), 42, sendBuf)
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("expected EOF, got %v", err)
+	}
+
+	selectCmd := <-sendBuf
+	if selectCmd.Cmd != "select" {
+		t.Fatalf("expected select command, got %q", selectCmd.Cmd)
+	}
+	if got := string(selectCmd.Args[0].([]byte)); got != "12" {
+		t.Fatalf("unexpected select arg: got %q want %q", got, "12")
+	}
+	if selectCmd.Offset != 42 {
+		t.Fatalf("unexpected offset: got %d want %d", selectCmd.Offset, 42)
+	}
+}
+
+func TestParseAofCommandEncodesMappedMultiDigitTargetDB(t *testing.T) {
+	ro := newReplyTestOutput()
+	ro.cfg.TargetDbMap = map[int]int{1: 15}
+	replayQuit := usync.NewWaitCloser(nil)
+	sendBuf := make(chan cmdExecution, 4)
+
+	var payload bytes.Buffer
+	writeAofCommand(t, &payload, "SELECT", "1")
+	writeAofCommand(t, &payload, "SET", "k", "v")
+
+	err := ro.parseAofCommand(replayQuit, bufio.NewReader(bytes.NewReader(payload.Bytes())), 0, sendBuf)
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("expected EOF, got %v", err)
+	}
+
+	selectCmd := <-sendBuf
+	if got := string(selectCmd.Args[0].([]byte)); got != "15" {
+		t.Fatalf("unexpected mapped select arg: got %q want %q", got, "15")
+	}
+	if selectCmd.Db != 15 {
+		t.Fatalf("unexpected mapped db: got %d want %d", selectCmd.Db, 15)
+	}
+
+	setCmd := <-sendBuf
+	if setCmd.Db != 15 {
+		t.Fatalf("unexpected mapped set db: got %d want %d", setCmd.Db, 15)
+	}
+}
+
 type fakeReplyBatcher struct {
 	cmds           []string
 	args           [][]interface{}
@@ -248,6 +335,7 @@ func newReplyTestOutput() *RedisOutput {
 	return NewRedisOutput(RedisOutputConfig{
 		InputName:              "127.0.0.1:6379",
 		CheckpointName:         "redis-gunyu-checkpoint:test-check-replies",
+		TargetDb:               -1,
 		BatchCmdCount:          1,
 		BatchBufferSize:        1024,
 		BatchTicker:            time.Hour,


### PR DESCRIPTION
## Summary

This PR fixes issue #108.

During AOF replay, GunYu synthesized `SELECT` commands by converting the DB index to a single byte. That worked for `DB 0` to `DB 9`, but failed for multi-digit DB indexes such as `10`, resulting in invalid Redis commands and replay failures.

## Root Cause

The replay path built `SELECT` arguments using single-byte character encoding logic instead of serializing the full DB number as a decimal string.

## Changes

- Replaced the single-byte DB encoding with full string serialization for synthesized `SELECT` commands
- Centralized `SELECT` command construction in a helper to avoid duplicate logic
- Added regression tests for:
  - AOF replay with `SELECT 10`
  - resume-from-breakpoint with a multi-digit DB
  - `targetDbMap` remapping to a multi-digit target DB

## Impact

This fixes standalone replay failures when:
- the source AOF switches to `DB >= 10`
- resume starts from `DB >= 10`
- DB remapping targets `DB >= 10`

## Validation

Verified with unit tests:
- `go test ./syncer`
- `go test ./pkg/redis/...`

## Notes

I did not find the same bug pattern in the RDB replay path. That path already uses integer-based DB selection.
